### PR TITLE
Use https consistently for gitmodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,12 +1,12 @@
 [submodule "external/riscv-opcodes"]
 	path = external/riscv-opcodes
-	url = git@github.com:riscv/riscv-opcodes.git
+	url = https://github.com/riscv/riscv-opcodes.git
 [submodule "external/picorv32"]
 	path = external/picorv32
 	url = https://github.com/cliffordwolf/picorv32.git
 [submodule "external/libscarv"]
 	path = external/libscarv
-	url = git@github.com:scarv/libscarv.git
+	url = https://github.com/scarv/libscarv.git
 [submodule "external/texmf"]
 	path = external/texmf
 	url = https://github.com/scarv/texmf.git


### PR DESCRIPTION
Otherwise this is annoying if you don't have a github ssh key installed.

Signed-off-by: Justin Cormack <justin@specialbusservice.com>