### PR TITLE
Fix signal used before declaration in multiple Verilog files

### DIFF
--- a/rtl/xc_aesmix/xc_aesmix.v
+++ b/rtl/xc_aesmix/xc_aesmix.v
@@ -24,6 +24,8 @@ output wire [31:0] result  //
 // Single cycle implementation (set) or 4-cycle implementation (clear).
 parameter FAST = 1'b1;
 
+wire [7:0] step_out;
+
 //
 // Multiply by 2 in GF(2^8) modulo 8'h1b
 function [7:0] xtime2;
@@ -181,7 +183,7 @@ wire [7:0] dec_byte     = dec_0_out ^ dec_1_out ^ dec_2_out ^ dec_3_out;
 //
 // Result collection
 
-wire [7:0] step_out     = enc ? enc_byte : dec_byte;
+assign step_out         = enc ? enc_byte : dec_byte;
 
 assign     result_enc       = {b_3, b_2, b_1, b_0};
 assign     result_dec       = {b_3, b_2, b_1, b_0};

--- a/rtl/xc_malu/xc_malu.v
+++ b/rtl/xc_malu/xc_malu.v
@@ -51,6 +51,17 @@ output wire         ready             // Outputs ready.
 
 );
 
+wire fsm_init;
+wire fsm_mdr;
+wire fsm_msub_1;
+wire fsm_macc_1;
+wire fsm_mmul_1;
+wire fsm_mmul_2;
+wire fsm_mmul_3;
+wire fsm_done;
+
+wire ld_mdr;
+wire ld_long;
 
 //
 // Submodule interface wires
@@ -145,14 +156,14 @@ localparam FSM_MMUL_2   = 8'b00100000;
 localparam FSM_MMUL_3   = 8'b01000000;
 localparam FSM_DONE     = 8'b10000000;
 
-wire fsm_init   = fsm[0];
-wire fsm_mdr    = fsm[1];
-wire fsm_msub_1 = fsm[2];
-wire fsm_macc_1 = fsm[3];
-wire fsm_mmul_1 = fsm[4];
-wire fsm_mmul_2 = fsm[5];
-wire fsm_mmul_3 = fsm[6];
-wire fsm_done   = fsm[7];
+assign fsm_init   = fsm[0];
+assign fsm_mdr    = fsm[1];
+assign fsm_msub_1 = fsm[2];
+assign fsm_macc_1 = fsm[3];
+assign fsm_mmul_1 = fsm[4];
+assign fsm_mmul_2 = fsm[5];
+assign fsm_mmul_3 = fsm[6];
+assign fsm_done   = fsm[7];
 
 always @(*) begin 
     
@@ -226,8 +237,8 @@ reg  [63:0] acc         ; // Accumulator
 
 // Route outputs of MDR instruction into registers. Can happen even if
 // there isn't an MDR instruction executing, as in the case of xc.mmul.
-wire        ld_mdr   = insn_mdr  ||  ((fsm_init||fsm_mmul_1) && uop_mmul);
-wire        ld_long  = insn_long && !((fsm_init||fsm_mmul_1) && uop_mmul);
+assign ld_mdr   = insn_mdr  ||  ((fsm_init||fsm_mmul_1) && uop_mmul);
+assign ld_long  = insn_long && !((fsm_init||fsm_mmul_1) && uop_mmul);
 
 wire [63:0] n_acc    = {64{ld_mdr   }} &  mdr_n_acc  |
                        {64{ld_long  }} & long_n_acc  ;

--- a/rtl/xc_malu/xc_malu_divrem.v
+++ b/rtl/xc_malu/xc_malu_divrem.v
@@ -32,13 +32,13 @@ output wire         ready
 
 reg         div_run     ;
 
+wire        div_finished= (div_run && count == 32);
 assign      ready       = div_finished;
 
 wire        signed_lhs  = (op_signed) && rs1[31];
 wire        signed_rhs  = (op_signed) && rs2[31];
 
 wire        div_start   = valid     && !div_run;
-wire        div_finished= (div_run && count == 32);
 
 wire [31:0] qmask       = (32'b1<<31  ) >> count  ;
 


### PR DESCRIPTION
Hi there!

Some tools (e.g., Modelsim) require signals to be declared before being used.
There were some violations of this policy in this repository.
This PR fixes this problem, without introducing any change to the resulting design.

Thanks!
Flavien